### PR TITLE
fix: verify provided token is of correct type

### DIFF
--- a/src/core/auth/auth.service.ts
+++ b/src/core/auth/auth.service.ts
@@ -1,25 +1,26 @@
-import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
-import { CreateUserDto } from '@/user/dto/create-user.dto';
-import { PrismaService } from '@/core/database/prisma.service';
-import { compare, hash } from 'bcrypt';
-import { ConfigService } from '@nestjs/config';
-import { Prisma, User } from '@prisma/client';
-import { PrismaError } from '@/core/database/prisma-error.enum';
-import { offendingFields } from '@/common/utils/prisma';
-import { RedisService } from '@/core/redis/redis.service';
-import { JwtService } from '@nestjs/jwt';
+import {HttpException, HttpStatus, Injectable} from '@nestjs/common';
+import {CreateUserDto} from '@/user/dto/create-user.dto';
+import {PrismaService} from '@/core/database/prisma.service';
+import {compare, hash} from 'bcrypt';
+import {ConfigService} from '@nestjs/config';
+import {Prisma, User} from '@prisma/client';
+import {PrismaError} from '@/core/database/prisma-error.enum';
+import {offendingFields} from '@/common/utils/prisma';
+import {RedisService} from '@/core/redis/redis.service';
+import {JwtService} from '@nestjs/jwt';
 import {
     AccessPayload,
     FullAccessPayload,
     FullRefreshPayload,
     RefreshPayload,
-    TokenFingerprintPair
+    TokenFingerprintPair,
+    TokenType
 } from '@/core/auth/dto/jwt.dto';
-import { generateFingerprint, sha256 } from '@/common/utils/crypto';
+import {generateFingerprint, sha256} from '@/common/utils/crypto';
 import * as AuthExceptions from '@/common/exceptions/auth';
-import { TokenExpiredError, JsonWebTokenError } from 'jsonwebtoken';
-import { MailService } from '@/common/services/mail/mail.service';
-import { PrismaClientKnownRequestError } from '@prisma/client/runtime';
+import {JsonWebTokenError, TokenExpiredError} from 'jsonwebtoken';
+import {MailService} from '@/common/services/mail/mail.service';
+import {PrismaClientKnownRequestError} from '@prisma/client/runtime';
 
 export type UserNoPassword = Omit<User, 'password'>;
 
@@ -174,14 +175,22 @@ export class AuthService {
     }
 
     async useAccessToken(token: string): Promise<FullAccessPayload> {
-        return await this.jwtService.verifyAsync<FullAccessPayload>(token).catch((e) => {
-            if (e instanceof TokenExpiredError) {
-                throw new AuthExceptions.TokenExpired();
-            } else if (e instanceof JsonWebTokenError) {
-                throw new AuthExceptions.TokenInvalid();
-            }
-            throw e;
-        });
+        const payload: FullAccessPayload = await this.jwtService
+            .verifyAsync<FullAccessPayload>(token)
+            .catch((e) => {
+                if (e instanceof TokenExpiredError) {
+                    throw new AuthExceptions.TokenExpired();
+                } else if (e instanceof JsonWebTokenError) {
+                    throw new AuthExceptions.TokenInvalid();
+                }
+                throw e;
+            });
+
+        if (payload.t !== TokenType.ACCESS) {
+            throw new AuthExceptions.TokenInvalid();
+        }
+
+        return payload;
     }
 
     async useRefreshToken(token: string, fingerprint: string): Promise<UserNoPassword> {
@@ -193,6 +202,10 @@ export class AuthService {
             }
             throw e;
         });
+
+        if (payload.t !== TokenType.REFRESH) {
+            throw new AuthExceptions.TokenInvalid();
+        }
 
         if (sha256(fingerprint) !== payload.fingerprint) {
             throw new AuthExceptions.FingerprintMismatch();

--- a/src/core/auth/auth.service.ts
+++ b/src/core/auth/auth.service.ts
@@ -147,6 +147,7 @@ export class AuthService {
     async grantAccessToken(user: UserNoPassword, restricted?: boolean): Promise<string> {
         return await this.jwtService.signAsync(
             <AccessPayload>{
+                t: TokenType.ACCESS,
                 username: user.username,
                 restricted
             },
@@ -162,6 +163,7 @@ export class AuthService {
         const expirySeconds = parseInt(this.config.get<string>('auth.jwt.time.refresh'));
 
         const payload: RefreshPayload = {
+            t: TokenType.REFRESH,
             fingerprint: sha256(fingerprint),
             username: user.username
         };

--- a/src/core/auth/auth.service.ts
+++ b/src/core/auth/auth.service.ts
@@ -1,13 +1,13 @@
-import {HttpException, HttpStatus, Injectable} from '@nestjs/common';
-import {CreateUserDto} from '@/user/dto/create-user.dto';
-import {PrismaService} from '@/core/database/prisma.service';
-import {compare, hash} from 'bcrypt';
-import {ConfigService} from '@nestjs/config';
-import {Prisma, User} from '@prisma/client';
-import {PrismaError} from '@/core/database/prisma-error.enum';
-import {offendingFields} from '@/common/utils/prisma';
-import {RedisService} from '@/core/redis/redis.service';
-import {JwtService} from '@nestjs/jwt';
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { CreateUserDto } from '@/user/dto/create-user.dto';
+import { PrismaService } from '@/core/database/prisma.service';
+import { compare, hash } from 'bcrypt';
+import { ConfigService } from '@nestjs/config';
+import { Prisma, User } from '@prisma/client';
+import { PrismaError } from '@/core/database/prisma-error.enum';
+import { offendingFields } from '@/common/utils/prisma';
+import { RedisService } from '@/core/redis/redis.service';
+import { JwtService } from '@nestjs/jwt';
 import {
     AccessPayload,
     FullAccessPayload,
@@ -16,11 +16,11 @@ import {
     TokenFingerprintPair,
     TokenType
 } from '@/core/auth/dto/jwt.dto';
-import {generateFingerprint, sha256} from '@/common/utils/crypto';
+import { generateFingerprint, sha256 } from '@/common/utils/crypto';
 import * as AuthExceptions from '@/common/exceptions/auth';
-import {JsonWebTokenError, TokenExpiredError} from 'jsonwebtoken';
-import {MailService} from '@/common/services/mail/mail.service';
-import {PrismaClientKnownRequestError} from '@prisma/client/runtime';
+import { JsonWebTokenError, TokenExpiredError } from 'jsonwebtoken';
+import { MailService } from '@/common/services/mail/mail.service';
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime';
 
 export type UserNoPassword = Omit<User, 'password'>;
 

--- a/src/core/auth/dto/jwt.dto.ts
+++ b/src/core/auth/dto/jwt.dto.ts
@@ -1,11 +1,17 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 
+export enum TokenType {
+    ACCESS = 'A',
+    REFRESH = 'R'
+}
+
 export interface TokenFingerprintPair {
     token: string;
     fingerprint: string;
 }
 
 export interface RefreshPayload {
+    t: TokenType.REFRESH;
     fingerprint: string;
     username: string;
     // todo: add permissions/roles
@@ -16,6 +22,7 @@ export interface FullRefreshPayload extends RefreshPayload {
 }
 
 export interface AccessPayload {
+    t: TokenType.ACCESS;
     username: string;
     restricted?: boolean;
 }


### PR DESCRIPTION
Resolves #1 by introducing an additional field to specify type, and validating the specific type matches the expected type in the appropriate `useToken` method.

Will let @wesamjabali take a look.